### PR TITLE
Add pic-encode/decode support for Saku (version 3)

### DIFF
--- a/Compression/ShinTextureCompress.cs
+++ b/Compression/ShinTextureCompress.cs
@@ -161,6 +161,7 @@ namespace ShinDataUtil.Compression
             public bool Quantize { get; set; }
             public bool Dither { get; set; }
             public bool LosslessAlpha { get; set; }
+            public bool IsVersion3 { get; set; }
         }
         
         public static unsafe int EncodeImageFragment(Stream outfrag, Image<Rgba32> image,

--- a/Decompression/ShinTextureDecompress.cs
+++ b/Decompression/ShinTextureDecompress.cs
@@ -29,7 +29,7 @@ namespace ShinDataUtil.Decompression
                     var v = dictionary[input[i]];
                     if (inputAlpha.Length > 0)
                     {
-                        Debug.Assert(v.A == 255);
+                        Debug.Assert(v.A == 255 || v.A == 0);
                         v.A = inputAlpha[i];
                     }
 

--- a/Program.cs
+++ b/Program.cs
@@ -391,6 +391,9 @@ namespace ShinDataUtil
                     case "--lossless-alpha":
                         compressionConfig.LosslessAlpha = true;
                         break;
+                    case "--version3":
+                        compressionConfig.IsVersion3 = true;
+                        break;
                     default:
                         throw new ArgumentException($"Unknown option: {opt}");
                 }


### PR DESCRIPTION
This patch adds support for editing PICs for the Switch version of "Umineko no Naku Koro ni" and closes #13. Further testing is needed.